### PR TITLE
Made it so that encoders and gyro get reset at the start of Kaos mode…

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,6 +111,9 @@ void kaos()
 {
   uint8_t target_x = PersistantStorage::getTargetXLocation();
   uint8_t target_y = PersistantStorage::getTargetYLocation();
+
+  Orientation* orientation = Orientation::getInstance();
+
   if (knowsBestPath(target_x, target_y)) {
     Compass8 absolute_end_direction;
 
@@ -124,6 +127,12 @@ void kaos()
 
     gUserInterface.waitForHand();
     speedRunMelody();
+
+    enc_left_front_write(0);
+    enc_right_front_write(0);
+    enc_left_back_write(0);
+    enc_right_back_write(0);
+    orientation->resetHeading();
 
     absolute_end_direction = parser.getEndDirection();
 


### PR DESCRIPTION
… run. Aim to fix bug where moving robot before swiping in front of bot will cause errors in run. Also, may also fix issue where kaos mode fails after playing start melody and doing nothing. 

Has been tested on bot and no discernible issues, save now that Kaos mode run does not fail. 