### PR TITLE
waitforHand() fix

### DIFF
--- a/src/conf.h
+++ b/src/conf.h
@@ -117,7 +117,7 @@
 
 // Hand swipe start
 #define HAND_SWIPE_START_TIME 500 // in millis
-#define HAND_SWIPE_HEADING_TOLERANCE 0.05 // in degrees
+#define HAND_SWIPE_HEADING_TOLERANCE 1 // in degrees/100ms
 #define HAND_SWIPE_FORWARD_RANGE 50
 #define HAND_SWIPE_DIAG_RANGE 85
 
@@ -191,7 +191,7 @@
 #define MAX_DECEL_STRAIGHT -5 // m/s/s
 #define MAX_ACCEL_ROTATE 2 // m/s/s
 #define MAX_DECEL_ROTATE -2 // m/s/s
-#define MAX_ACCEL_CORNER 3 // m/s/s  
+#define MAX_ACCEL_CORNER 3 // m/s/s
 #define MAX_DECEL_CORNER -3 // m/s/s
 
 
@@ -213,7 +213,7 @@
 #define VELOCITY_PER_VBEMF (RATED_RPM_PER_VBEMF * STEPS_PER_MOTOR_REV * GEAR_RATIO * MM_PER_STEP / (60000)) // 60000 is for mm to m and s to min
 #define FRICTION_FORCE (RATED_FREERUN_CURRENT * FORCE_PER_AMP + 0.10) // Newtons (0.08 calculated Newtons from motor/gearbox)  amount of force opposing motion in robot including rolling resistance, sliding, gearing
 
-//  TODO precompile, calculate max velocity based on turn radius and max accel, which will then limit max velocity through centripital force.  
+//  TODO precompile, calculate max velocity based on turn radius and max accel, which will then limit max velocity through centripital force.
 //    if this max velocity is higher than max straight velocity then use max straight velocity
 #define MAX_VEL_ROTATE .5 // m/s
 
@@ -221,7 +221,7 @@
 #define MOTION_RESET_BACKUP_DISTANCE 50
 #define MOTION_RESET_HOLD_DISTANCE 22
 
-// Zll forward speeds should be the same, and should be the maximum turn speed.  
+// Zll forward speeds should be the same, and should be the maximum turn speed.
 // All max angular accelerations can be the same, but don't have to be
 // highest reliable max angular accel is most accurate turn
 //  max angular accel can be calculated with below equation

--- a/src/device/Orientation.h
+++ b/src/device/Orientation.h
@@ -24,7 +24,7 @@ class Orientation {
     int16_t last_gyro_reading_ = 0;
     unsigned long last_update_time_ = 0;
     volatile unsigned long next_update_time_ = 0;
-    
+
     float max_forward_accel_ = 0;
     float max_radial_accel_ = 0;
 
@@ -40,7 +40,7 @@ class Orientation {
     float mag_heading_offset_;
     float last_mag_heading_;
   public:
-    bool handler_update_ = false;
+    bool handler_update_ = true;
     static Orientation* getInstance();
 
     // determine the right offset for the gyro
@@ -61,7 +61,7 @@ class Orientation {
     // This does not wrap around, so it will continue increasing past 360
     //   or decreasing past -360
     float getHeading();
-    
+
     void resetMaxForwardAccel();
     void resetMaxRadialAccel();
     float getMaxForwardAccel();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,6 +73,8 @@ void micromouse_main()
 
   LOG_INIT();
 
+  Orientation::getInstance()->resetHeading();
+
   MenuItem items[] = {
     { "RUN", run },
     { "KAOS", kaos },

--- a/src/user_interaction/PlayMelodies.cpp
+++ b/src/user_interaction/PlayMelodies.cpp
@@ -25,7 +25,7 @@ void speedRunMelody() { // time warning sound
 
 
 void crashMelody() { // either death sounds or game over sound
-  
+
   int tempo = 400; // tempo in beats per minute
 
   // set duration of a whole note
@@ -48,7 +48,7 @@ void crashMelody() { // either death sounds or game over sound
 
 
 void speedFinishMelody() { // flagpole fanfare
-  
+
   int tempo = 300; // tempo in beats per minute
 
   // set duration of a whole note
@@ -108,8 +108,8 @@ void stopMelody() { // pause sound
     NOTE_E6, NOTE_C6, NOTE_E6, NOTE_C6
   };
 
-  float note_duration[] = { 
-    0.16666, 0.16666, 0.16666, 0.5 
+  float note_duration[] = {
+    0.16666, 0.16666, 0.16666, 0.5
   };
 
   // send notes to playing function
@@ -130,7 +130,7 @@ void startMelody() {
     NOTE_E5, NOTE_E5, 0, NOTE_E5, 0, NOTE_C5, NOTE_E5, 0, NOTE_G5, 0, NOTE_G4
   };
 
-  float note_duration[] = { 
+  float note_duration[] = {
     0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.75, 1
   };
 
@@ -141,6 +141,12 @@ void startMelody() {
 }
 
 
+void handSeenMelody() {
+  playNote(NOTE_C6, 100);
+  delay(100);
+  playNote(NOTE_C6, 100);
+}
+
 void playNote(int note_frequency, int note_duration) {
 
   if (note_frequency > 0) {
@@ -150,13 +156,13 @@ void playNote(int note_frequency, int note_duration) {
     noTone(BUZZER_PIN);
     delay(pause_between_notes);
 
-    
+
 //    analogWriteFrequency(BUZZER_PIN, note_frequency);
 //    analogWrite(BUZZER_PIN, 512);
 //    delay(note_duration - pause_between_notes); // duration in millis
 //    analogWrite(BUZZER_PIN, 0);
 //    delay(pause_between_notes);
-    
+
   }
   else {
     delay(note_duration);
@@ -167,4 +173,3 @@ void playNote(int note_frequency, int note_duration) {
   analogWriteFrequency(MOTOR_LB_PWM_PIN, 46875);
   analogWriteFrequency(MOTOR_RB_PWM_PIN, 46875);
 }
-

--- a/src/user_interaction/PlayMelodies.h
+++ b/src/user_interaction/PlayMelodies.h
@@ -97,12 +97,14 @@ void speedRunMelody(); // time warning sound
 void crashMelody(); // either death sounds or game over sound
 
 void speedFinishMelody(); // flagpole fanfare
-  
+
 void searchFinishMelody(); //
 
 void stopMelody(); // pause sound
 
 void startMelody(); // main theme
+
+void handSeenMelody(); // seen hand sound
 
 void playNote(int note_frequency, int note_duration); //
 

--- a/src/user_interaction/UserInterface.cpp
+++ b/src/user_interaction/UserInterface.cpp
@@ -249,12 +249,6 @@ void UserInterface::waitForHand()
   bool readyToStart = false;
   int state = 0;
 
-  RangeSensors.frontRightSensor.updateRange();
-  RangeSensors.diagRightSensor.updateRange();
-
-  float sensorRight = RangeSensors.frontRightSensor.getRange();
-  float sensorLeft = RangeSensors.diagRightSensor.getRange();
-
   while (!readyToStart) {
 
     checkBattery();
@@ -270,9 +264,7 @@ void UserInterface::waitForHand()
       else if ( RangeSensors.frontRightSensor.getRange() < HAND_SWIPE_FORWARD_RANGE // We see a hand
                 && RangeSensors.diagRightSensor.getRange() < HAND_SWIPE_DIAG_RANGE ) {
                   state = 1;
-                  playNote(NOTE_C6, 100);
-                  delay(100);
-                  playNote(NOTE_C6, 100);
+                  handSeenMelody();
       }
 
     }

--- a/src/user_interaction/UserInterface.cpp
+++ b/src/user_interaction/UserInterface.cpp
@@ -7,7 +7,6 @@
 #include "../legacy_motion/PIDController.h"
 #include "PlayMelodies.h"
 #include "UserInterface.h"
-#include "../Log.h"
 
 UserInterface gUserInterface;
 
@@ -269,7 +268,7 @@ void UserInterface::waitForHand()
 
     if ( state == 0 ) { // Waiting for hand
       // Robot has moved significantly
-      if (delta_heading > 1) {
+      if (delta_heading > HAND_SWIPE_HEADING_TOLERANCE) {
         state = 2;
       }
       else if ( sensorRight < HAND_SWIPE_FORWARD_RANGE // We see a hand
@@ -278,7 +277,7 @@ void UserInterface::waitForHand()
     }
     else if ( state == 1 ) { // We saw a hand, now wait for it to go away
       // Robot has moved significantly, bail out
-      if (delta_heading > 1) {
+      if (delta_heading > HAND_SWIPE_HEADING_TOLERANCE) {
         state = 2;
       }
       else if ( sensorRight > HAND_SWIPE_FORWARD_RANGE

--- a/src/user_interaction/UserInterface.cpp
+++ b/src/user_interaction/UserInterface.cpp
@@ -261,27 +261,28 @@ void UserInterface::waitForHand()
     RangeSensors.frontRightSensor.updateRange();
     RangeSensors.diagRightSensor.updateRange();
 
-    sensorRight = (sensorRight*0.3) + (RangeSensors.frontRightSensor.getRange()*0.7);
-    sensorLeft = (sensorLeft*0.3) + (RangeSensors.diagRightSensor.getRange()*0.7);
-
     float delta_heading = abs(heading - orientation->getHeading());
 
     if ( state == 0 ) { // Waiting for hand
       // Robot has moved significantly
-      if (delta_heading > HAND_SWIPE_HEADING_TOLERANCE) {
+      if (delta_heading > HAND_SWIPE_HEADING_TOLERANCE)
         state = 2;
+      else if ( RangeSensors.frontRightSensor.getRange() < HAND_SWIPE_FORWARD_RANGE // We see a hand
+                && RangeSensors.diagRightSensor.getRange() < HAND_SWIPE_DIAG_RANGE ) {
+                  state = 1;
+                  playNote(NOTE_C6, 100);
+                  delay(100);
+                  playNote(NOTE_C6, 100);
       }
-      else if ( sensorRight < HAND_SWIPE_FORWARD_RANGE // We see a hand
-                || sensorLeft < HAND_SWIPE_DIAG_RANGE )
-                state = 1;
+
     }
     else if ( state == 1 ) { // We saw a hand, now wait for it to go away
-      // Robot has moved significantly, bail out
+      // Robot has moved significantly
       if (delta_heading > HAND_SWIPE_HEADING_TOLERANCE) {
         state = 2;
       }
-      else if ( sensorRight > HAND_SWIPE_FORWARD_RANGE
-                || sensorLeft > HAND_SWIPE_DIAG_RANGE )
+      else if ( RangeSensors.frontRightSensor.getRange() > HAND_SWIPE_FORWARD_RANGE
+                && RangeSensors.diagRightSensor.getRange() > HAND_SWIPE_DIAG_RANGE )
               readyToStart = true;
     }
     else if ( state == 2 ) { // Robot moved

--- a/src/user_interaction/UserInterface.cpp
+++ b/src/user_interaction/UserInterface.cpp
@@ -7,6 +7,7 @@
 #include "../legacy_motion/PIDController.h"
 #include "PlayMelodies.h"
 #include "UserInterface.h"
+#include "../Log.h"
 
 UserInterface gUserInterface;
 
@@ -245,51 +246,51 @@ void UserInterface::checkBattery()
 void UserInterface::waitForHand()
 {
   Orientation* orientation = Orientation::getInstance();
-  bool gyro_failed = true;
-  float initial_heading = orientation->getHeading();
-  uint32_t time = millis();
+  float heading = orientation->getHeading();
+  bool readyToStart = false;
+  int state = 0;
 
-  while (gyro_failed) {
-    gyro_failed = false;
-    while (millis() - time < HAND_SWIPE_START_TIME) {
-      float delta_heading = abs(orientation->getHeading() - initial_heading);
-      if (delta_heading > HAND_SWIPE_HEADING_TOLERANCE) {
-        time = millis();
-        initial_heading = orientation->getHeading();
+  RangeSensors.frontRightSensor.updateRange();
+  RangeSensors.diagRightSensor.updateRange();
+
+  float sensorRight = RangeSensors.frontRightSensor.getRange();
+  float sensorLeft = RangeSensors.diagRightSensor.getRange();
+
+  while (!readyToStart) {
+
+    checkBattery();
+    RangeSensors.frontRightSensor.updateRange();
+    RangeSensors.diagRightSensor.updateRange();
+
+    sensorRight = (sensorRight*0.3) + (RangeSensors.frontRightSensor.getRange()*0.7);
+    sensorLeft = (sensorLeft*0.3) + (RangeSensors.diagRightSensor.getRange()*0.7);
+
+    float delta_heading = abs(heading - orientation->getHeading());
+
+    if ( state == 0 ) { // Waiting for hand
+      // Robot has moved significantly
+      if (delta_heading > 1) {
+        state = 2;
       }
-      checkBattery();
+      else if ( sensorRight < HAND_SWIPE_FORWARD_RANGE // We see a hand
+                || sensorLeft < HAND_SWIPE_DIAG_RANGE )
+                state = 1;
     }
-
-    do {
-      RangeSensors.frontRightSensor.updateRange();
-      RangeSensors.diagRightSensor.updateRange();
-      float delta_heading = abs(orientation->getHeading() - initial_heading);
-      if (delta_heading > HAND_SWIPE_HEADING_TOLERANCE) {
-        time = millis();
-        initial_heading = orientation->getHeading();
-        gyro_failed = true;
-        break;
+    else if ( state == 1 ) { // We saw a hand, now wait for it to go away
+      // Robot has moved significantly, bail out
+      if (delta_heading > 1) {
+        state = 2;
       }
-      checkBattery();
-    } while (RangeSensors.frontRightSensor.getRange() > HAND_SWIPE_FORWARD_RANGE
-              || RangeSensors.diagRightSensor.getRange() > HAND_SWIPE_DIAG_RANGE);
-
-    if (!gyro_failed) {
-      do {
-        RangeSensors.frontRightSensor.updateRange();
-        RangeSensors.diagRightSensor.updateRange();
-        float delta_heading = abs(orientation->getHeading() - initial_heading);
-        if (delta_heading > HAND_SWIPE_HEADING_TOLERANCE) {
-          time = millis();
-          initial_heading = orientation->getHeading();
-          gyro_failed = true;
-          break;
-        }
-        checkBattery();
-      } while (RangeSensors.frontRightSensor.getRange() < HAND_SWIPE_FORWARD_RANGE
-                || RangeSensors.diagRightSensor.getRange() < HAND_SWIPE_DIAG_RANGE);
+      else if ( sensorRight > HAND_SWIPE_FORWARD_RANGE
+                || sensorLeft > HAND_SWIPE_DIAG_RANGE )
+              readyToStart = true;
     }
+    else if ( state == 2 ) { // Robot moved
+      delay(100);
+      state = 0; // Back to waiting for hand
+    }
+    heading = orientation->getHeading();
+
+    delay(100);
   }
-  
-  delay(100);
 }


### PR DESCRIPTION
## Reimplemented `waitForHand()`
- Uses a state machine
- Averages IR sensor values
- Measures gyro movement over 100ms instead of looking at heading since last reset (last implementation would reset randomly due to drift)

- Orientation now starts in the state where it uses interrupts for gyro integration - This is the default state coming out of a run.

Potential fix for #82
